### PR TITLE
Added a bind function to bind SD Layer to SOMEIP Layer

### DIFF
--- a/scapy/contrib/automotive/someip_sd.py
+++ b/scapy/contrib/automotive/someip_sd.py
@@ -346,3 +346,17 @@ class SD(_SDPacketBase):
             return (p / self)
         else:
             return (p)
+       
+def _bind_sd_layer():
+    """
+    Bind SD to SOMEIP
+    """
+    #doesn't work, but it's a good start
+    
+    #Service Discovery messages shall use the Service-ID (16Bits) of 0xFFFF
+    bind_layers(SOMEIP, SD, msg_id.srv_id = 0xffff)
+    
+    #Service Discovery messages shall use the Method-ID (16Bits) of 0x8100
+    bind_layers(SOMEIP, SD, msg_id.method_id = 0x8100)
+    
+_bind_sd_layer()


### PR DESCRIPTION
Still not a final solution, because the keyword in the bind_layers function 'can't be an expression' (SyntaxError)

This is just a checklist to guide you. You can remove it safely.

**Checklist:**

-   [x] If you are new to Scapy: I have checked <https://github.com/secdev/scapy/blob/master/CONTRIBUTING.md> (esp. section submitting-pull-requests)
-   [x] I squashed commits belonging together
-   [ ] I added unit tests or explained why they are not relevant
-   [ ] I executed the regression tests for Python2 and Python3 (using `tox` or, `cd test && ./run_tests_py2, cd test && ./run_tests_py3`)

> brief description what this PR will do, e.g. fixes broken dissection of XXX

> if required - short explanation why you fixed something in a way that may look more complicated as it actually is

> if required - outline impacts on other parts of the library

fixes #xxx (add issue number here if appropriate, else remove this line)
